### PR TITLE
Update ASP.NET Core GSoC proposals

### DIFF
--- a/aspnet.md
+++ b/aspnet.md
@@ -1,13 +1,18 @@
 ## ASP.NET Core Analyzers
 **Complexity:** Medium
 
-[Roslyn Analyzers](https://github.com/dotnet/roslyn-analyzers) provide design-time diagnostics, code fixes and refactorings to developers based on a semantic understanding of the code. This project would build a set of analyzers for ASP.NET Core application development.
+[ASP.NET Core](https://github.com/aspnet/home) is a cross-platform, high-performance, open-source framework for building modern, cloud-based, we apps using .NET.
+
+[Roslyn Analyzers](https://github.com/dotnet/roslyn-analyzers) provide design-time diagnostics, code fixes, and refactorings to developers based on a semantic understanding of the code. This project would build a set of analyzers for ASP.NET Core application development.
 
 Deliverables:
- * {any additional deliverables}
- * (Optional) {any additional optional deliverables}
+ * MVC analyzer (https://github.com/aspnet/specs/issues/110)
+   * Check for actions or page handlers that don't return IActionResult
+   * Check for async actions or page handlers that return void instead of Task
+ * Logging analyzer (https://github.com/aspnet/Logging/issues/712)
+ * Middleware ordering analyzer
 
-**Mentors**: {mentor name}
+**Mentors**: [Daniel Roth](https://github.com/danroth27/), [Pranav Krishnamoorthy](https://github.com/pranavkm)
 
 ## Complete WebHooks Port
 **Complexity:** Medium
@@ -15,43 +20,20 @@ Deliverables:
 The [ASP.NET WebHooks](https://github.com/aspnet/WebHooks) system allows for producing and consuming web hooks in .NET. A port to .NET Core has been started, but is not complete. This project would include completing the port to .NET core and creating updated integrations with webhook consumers and providers.
 
 Deliverables:
- * Complete ASP.NET Core WebHooks port
- * {any additional deliverables}
- * (Optional) {any additional optional deliverables}
+ * Port additional WebHook receivers from ASP.NET WebHooks to ASP.NET Core WebHooks
+ * Port sender-side WebHook functionality from ASP.NET WebHooks to ASP.NET Core WebHooks
+ * Port ASP.NET Web Hooks samples to ASP.NET Core WebHooks
 
-**Mentors**: [Doug Bunting](https://github.com/dougbu)
+**Mentors**: [Daniel Roth](https://github.com/danroth27/), [Doug Bunting](https://github.com/dougbu)
 
-## Health Checks
+## Blazor
 **Complexity:** Medium
 
-The [Health Checks](https://docs.microsoft.com/en-us/dotnet/standard/microservices-architecture/implement-resilient-applications/monitor-app-health) library provides features that let you validate that any specific external resource needed for your application (like a SQL Server database or remote API) is working properly. The library is designed for extensibility, as it allows implementers to decide what it means that the resource is healthy. An early release of this libary was completed, but prior to release the items listed in the deliverables list below must be completed.
+[Blazor](https://github.com/aspnet/blazor) is a new experimental framework for building browser-based web applications with .NET and [WebAssembly](http://webassembly.org).
 
 Deliverables:
- * {deliverables}
- * {any additional deliverables}
- * (Optional) {any additional optional deliverables}
+ * Build sample Blazor applications and provide feedback on the framework
+ * Analysis and optimization of .NET runtime assemblies to determine optimal trimming of unneeded code
+ * Tooling for generating strongly typed C# wrappers for JavaScript libraries based on TypeScript definitions
 
-**Mentors**: {mentors}
-
-## {Something to do with Blazor}
-**Complexity:** Medium
-
-{description}
-
-Deliverables:
- * {deliverables}
- * {any additional deliverables}
- * (Optional) {any additional optional deliverables}
-
-**Mentors**: Steven Sanderson
-
-## Tag Helpers for {something something}
-**Complexity:** Medium
-
-{any ideas?}
-
-Deliverables:
- * {any additional deliverables}
- * (Optional) {any additional optional deliverables}
-
-**Mentors**: {mentor name}
+**Mentors**: [Daniel Roth](https://github.com/danroth27/), [Steven Sanderson](https://github.com/SteveSandersonMS)


### PR DESCRIPTION
Remove Health Checks and Tag Helper proposals, as there are no proposed deliverables.

Fill out proposals for ASP.NET Core Analyzers, WebHooks, and Blazor.